### PR TITLE
Add cron control endpoints

### DIFF
--- a/src/adapters/controllers/jira/jira-cron.controller.ts
+++ b/src/adapters/controllers/jira/jira-cron.controller.ts
@@ -1,0 +1,39 @@
+// src/adapters/controllers/jira/jira-cron.controller.ts
+
+import { Controller, Post, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { JiraQueueMonitorService } from '@services/queue-monitor/jira-queue-monitor.service';
+
+/**
+ * JiraCronController
+ * ------------------
+ * Responsável apenas por expor endpoints para controle manual dos jobs Cron
+ * relacionados ao monitoramento de filas do Jira.
+ */
+@ApiTags('Jira Cron')
+@Controller('jira/monitor/cron')
+export class JiraCronController {
+  private readonly logger = new Logger(JiraCronController.name);
+
+  constructor(private readonly jiraMonitorService: JiraQueueMonitorService) {}
+
+  /** Inicia o job Cron manualmente */
+  @ApiOperation({ summary: 'Iniciar cron de monitoramento' })
+  @ApiResponse({ status: 201, description: 'Cron iniciado.' })
+  @Post('start')
+  startCron(): { message: string } {
+    this.logger.log('Iniciando cron via endpoint');
+    this.jiraMonitorService.startCron();
+    return { message: 'Cron iniciado' };
+  }
+
+  /** Interrompe o job Cron manualmente */
+  @ApiOperation({ summary: 'Parar cron de monitoramento' })
+  @ApiResponse({ status: 200, description: 'Cron parado.' })
+  @Post('stop')
+  stopCron(): { message: string } {
+    this.logger.log('Parando cron via endpoint');
+    this.jiraMonitorService.stopCron();
+    return { message: 'Cron parado' };
+  }
+}

--- a/src/adapters/controllers/jira/jira-monitor.controller.ts
+++ b/src/adapters/controllers/jira/jira-monitor.controller.ts
@@ -3,6 +3,7 @@
 import {
   Controller,
   Get,
+  Post,
   InternalServerErrorException,
   Query,
   BadRequestException,

--- a/src/application/services/queue-monitor/jira-queue-monitor.service.ts
+++ b/src/application/services/queue-monitor/jira-queue-monitor.service.ts
@@ -35,7 +35,7 @@ import {
 } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule';
 
 import { JiraCredentialRepository } from '@infra/repositories/jira/jira-credential.repository';
 import { ProcessIssuesUseCase } from '@app/usecases/jira/process-issues.usecase';
@@ -53,6 +53,7 @@ export class JiraQueueMonitorService {
     private readonly jiraCredRepo: JiraCredentialRepository, // Repositório para obter cloudId
     private readonly configService: ConfigService, // Acesso a variáveis de ambiente
     private readonly processIssuesUseCase: ProcessIssuesUseCase, // UseCase para processamento de issues
+    private readonly schedulerRegistry: SchedulerRegistry, // Controle dos crons
   ) {}
 
   /**
@@ -169,7 +170,7 @@ export class JiraQueueMonitorService {
    *   - Buscar e processar issues
    *   - Executar ações automáticas em issues abertas
    */
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'jira-fetch-cron' })
   async handleInterval() {
     const userId = 'default';
     this.logger.log(
@@ -259,5 +260,23 @@ export class JiraQueueMonitorService {
     }
 
     return result;
+  }
+
+  /** Inicia o cron agendado manualmente */
+  startCron(): void {
+    const job = this.schedulerRegistry.getCronJob('jira-fetch-cron');
+    if (!job.isActive) {
+      job.start();
+      this.logger.log('Cron jira-fetch-cron iniciado manualmente');
+    }
+  }
+
+  /** Interrompe a execução do cron agendado */
+  stopCron(): void {
+    const job = this.schedulerRegistry.getCronJob('jira-fetch-cron');
+    if (job.isActive) {
+      job.stop();
+      this.logger.log('Cron jira-fetch-cron parado manualmente');
+    }
   }
 }

--- a/src/modules/jira/jira.module.ts
+++ b/src/modules/jira/jira.module.ts
@@ -5,6 +5,7 @@ import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { JiraMonitorController } from '@adapters/controllers/jira/jira-monitor.controller';
+import { JiraCronController } from '@adapters/controllers/jira/jira-cron.controller';
 import { AuthService } from '@app/services/auth/auth.service';
 import { JiraQueueMonitorService } from '@app/services/queue-monitor/jira-queue-monitor.service';
 import { ProcessIssuesUseCase } from '@app/usecases/jira/process-issues.usecase';
@@ -22,9 +23,7 @@ import { JiraCredentialRepository } from '@infra/repositories/jira/jira-credenti
     // 3) Habilita o ScheduleModule para que decoradores como @Interval funcionem
     ScheduleModule.forRoot(),
   ],
-  controllers: [
-    JiraMonitorController, // <-- adiciona o controller aqui
-  ],
+  controllers: [JiraMonitorController, JiraCronController],
   providers: [
     // 4) Serviços e repositórios
     JiraCredentialRepository, // Repositório de credenciais


### PR DESCRIPTION
## Summary
- allow controlling Jira cron job via REST
- implement `startCron` and `stopCron` service methods
- expose new `/jira/monitor/cron/start` and `/jira/monitor/cron/stop` routes

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684c31f3194483318946b14f98c8a974